### PR TITLE
fix: use `axis...` instead of `dim...`, fix typing to support `NativeArray`, add more tests

### DIFF
--- a/src/shift_nth_row_n_steps/_main.py
+++ b/src/shift_nth_row_n_steps/_main.py
@@ -1,91 +1,168 @@
 import warnings
 
 import ivy
-from ivy import Array
+from ivy import Array, NativeArray
 
 
-def _take_slice(input: Array, start: int, end: int, axis: int) -> Array:
-    axis = axis % len(input.shape)
-    return input[
+def take_slice(a: Array | NativeArray, start: int, end: int, *, axis: int) -> Array:
+    """
+    numpy.take() alternative using slices. (faster) similar to torch.narrow().
+
+    Parameters
+    ----------
+    a : Array
+        The source array.
+    start : int
+        The index of the element to start from.
+    end : int
+        The index of the element to end at.
+    axis : int
+        The axis to take the slice from.
+
+    Returns
+    -------
+    Array
+        The sliced array.
+
+    """
+    axis = axis % len(a.shape)
+    return a[
         (slice(None),) * axis
         + (slice(start, end),)
-        + (slice(None),) * (len(input.shape) - axis - 1)
+        + (slice(None),) * (len(a.shape) - axis - 1)
+    ]
+
+
+def narrow(a: Array | NativeArray, start: int, length: int, *, axis: int) -> Array:
+    """
+    torch.narrow() in ivy.
+
+    Parameters
+    ----------
+    a : Array
+        The source array.
+    start : int
+        The index of the element to start from.
+    length : int
+        The length of the slice.
+    axis : int
+        The axis to narrow.
+
+    Returns
+    -------
+    Array
+        The narrowed array.
+
+    """
+    return take_slice(a, start, start + length, axis=axis)
+
+
+def select(a: Array | NativeArray, index: int, *, axis: int) -> Array:
+    """
+    torch.select() (!= numpy.select()) in ivy.
+
+    Parameters
+    ----------
+    a : Array
+        The source array.
+    index : int
+        The index of the element to select.
+    axis : int
+        The axis to select from.
+
+    Returns
+    -------
+    Array
+        The selected array.
+
+    """
+    axis = axis % len(a.shape)
+    return a[
+        (slice(None),) * axis + (index,) + (slice(None),) * (len(a.shape) - axis - 1)
     ]
 
 
 def shift_nth_row_n_steps_for_loop(
-    input: Array, *, dim_row: int = -2, dim_shift: int = -1, cut_padding: bool = False
+    a: Array | NativeArray,
+    *,
+    axis_row: int = -2,
+    axis_shift: int = -1,
+    cut_padding: bool = False,
 ) -> Array:
     """
     Shifts the nth row n steps to the right.
 
     Parameters
     ----------
-    input : Array
-        The input tensor.
-    dim_row : int, optional
-        The dimension of the row to shift, by default -2
-    dim_shift : int, optional
-        The dimension of the shift, by default -1
+    a : Array
+        The source array.
+    axis_row : int, optional
+        The axisension of the row to shift, by default -2
+    axis_shift : int, optional
+        The axisension of the shift, by default -1
     cut_padding : bool, optional
         Whether to cut additional columns, by default False
 
     Returns
     -------
     Array
-        The shifted tensor. If the input is (..., row, ..., shift, ...),
+        The shifted array. If the input is (..., row, ..., shift, ...),
         the output will be (..., row, ..., shift + row - 1, ...).
         [...,i,...,j,...] -> [...,i,...,j+i,...]
 
     """
     outputs = []
-    row_len = ivy.shape(input)[dim_row]
-    for i in range(ivy.shape(input)[dim_row]):
-        row = _take_slice(input, i, i + 1, axis=dim_row)
-        row_cut = _take_slice(row, 0, row_len - i, axis=dim_shift)
+    row_len = ivy.shape(a)[axis_row]
+    for i in range(ivy.shape(a)[axis_row]):
+        row = take_slice(a, i, i + 1, axis=axis_row)
+        row_cut = take_slice(row, 0, row_len - i, axis=axis_shift)
         zero_shape = list(ivy.shape(row))
-        zero_shape[dim_shift] = i
-        output = ivy.concat([ivy.zeros(zero_shape), row_cut], axis=dim_shift).squeeze(
-            axis=dim_row
+        zero_shape[axis_shift] = i
+        output = ivy.concat([ivy.zeros(zero_shape), row_cut], axis=axis_shift).squeeze(
+            axis=axis_row
         )
         outputs.append(output)
-    output = ivy.stack(outputs, axis=dim_row)
+    output = ivy.stack(outputs, axis=axis_row)
     return output
 
 
 def shift_nth_row_n_steps(
-    input: Array, *, dim_row: int = -2, dim_shift: int = -1, cut_padding: bool = False
+    a: Array | NativeArray,
+    *,
+    axis_row: int = -2,
+    axis_shift: int = -1,
+    cut_padding: bool = False,
 ) -> Array:
     """
     Shifts the nth row n steps to the right.
 
     Parameters
     ----------
-    input : Array
-        The input tensor.
-    dim_row : int, optional
-        The dimension of the row to shift, by default -2
-    dim_shift : int, optional
-        The dimension of the shift, by default -1
+    a : Array
+        The source array.
+    axis_row : int, optional
+        The axis of the row to shift, by default -2
+    axis_shift : int, optional
+        The axis of the shift, by default -1
     cut_padding : bool, optional
         Whether to cut additional columns, by default False
 
     Returns
     -------
     Array
-        The shifted tensor. If the input is (..., row, ..., shift, ...),
+        The shifted array. If the input is (..., row, ..., shift, ...),
         the output will be (..., row, ..., shift + row - 1, ...).
         [...,i,...,j,...] -> [...,i,...,j+i,...]
 
     """
-    # swap dim_row and -2, dim_shift and -1
-    dim_row_ = -2
-    dim_shift_ = -1
-    input = ivy.moveaxis(input, (dim_row, dim_shift), (dim_row_, dim_shift_))
+    # swap axis_row and -2, axis_shift and -1
+    axis_row_ = -2
+    axis_shift_ = -1
+    a = ivy.moveaxis(a, (axis_row, axis_shift), (axis_row_, axis_shift_))
 
-    shape = ivy.shape(input)
-    l_row = shape[dim_row_]
-    l_shift = shape[dim_shift_]
+    shape = ivy.shape(a)
+    l_row = shape[axis_row_]
+    l_shift = shape[axis_shift_]
     if cut_padding and l_shift < l_row:
         warnings.warn(
             "cut_padding is True, but s < r, which results in redundant computation.",
@@ -94,29 +171,29 @@ def shift_nth_row_n_steps(
 
     # first pad to [s, r] -> [s+r, r]
     output = ivy.pad(
-        input,
+        a,
         [(0, 0)] * (len(shape) - 1) + [(0, l_row)],
         mode="constant",
         constant_values=0,
     )
 
-    # flatten dim_shift_ to dim_row_
+    # flatten axis_shift_ to axis_row_
     flatten_shape = list(ivy.shape(output))
-    flatten_shape[dim_shift_] = 1
-    flatten_shape[dim_row_] = -1
-    output = output.reshape(flatten_shape).squeeze(axis=dim_shift_)
+    flatten_shape[axis_shift_] = 1
+    flatten_shape[axis_row_] = -1
+    output = output.reshape(flatten_shape).squeeze(axis=axis_shift_)
 
     # remove last padding, [(s+r)*r] -> [(s+r-1)*r]
-    output = _take_slice(output, 0, (l_shift + l_row - 1) * l_row, axis=dim_shift_)
+    output = take_slice(output, 0, (l_shift + l_row - 1) * l_row, axis=axis_shift_)
 
     # new shape is [s+r-1,r]
     result_shape = list(shape)
-    result_shape[dim_shift_] = l_shift + l_row - 1
+    result_shape[axis_shift_] = l_shift + l_row - 1
     output = output.reshape(result_shape)
 
     # cut padding
     if cut_padding:
-        output = _take_slice(output, 0, l_shift, axis=dim_shift_)
+        output = take_slice(output, 0, l_shift, axis=axis_shift_)
 
     # return the result
-    return ivy.moveaxis(output, (dim_row_, dim_shift_), (dim_row, dim_shift))
+    return ivy.moveaxis(output, (axis_row_, axis_shift_), (axis_row, axis_shift))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,10 @@ runner = CliRunner()
 
 
 def test_help():
-    """The help message includes the CLI name."""
     result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+
+
+def test_banchmark():
+    result = runner.invoke(app, ["--n-end", "2"])
     assert result.exit_code == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,8 @@
 import ivy
+import pytest
 
 from shift_nth_row_n_steps._main import (
+    select,
     shift_nth_row_n_steps,
     shift_nth_row_n_steps_for_loop,
 )
@@ -8,8 +10,56 @@ from shift_nth_row_n_steps._main import (
 ivy.set_backend("numpy")
 
 
-def test_shift_nth_row_n_steps() -> None:
+def test_shift_nth_row_n_steps_match() -> None:
     input = ivy.array([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]])
     expected = ivy.array([[[1, 2, 3], [0, 4, 5], [0, 0, 7]]])
     assert ivy.array_equal(shift_nth_row_n_steps(input, cut_padding=True), expected)
     assert ivy.array_equal(shift_nth_row_n_steps_for_loop(input), expected)
+
+
+@pytest.mark.parametrize(
+    "shape", [(1, 1, 1), (1, 1, 2), (1, 2, 1), (2, 7, 4), (2, 4, 7)]
+)
+@pytest.mark.parametrize(
+    "axis_row,axis_shift", [(-1, -2), (-2, -1), (-3, -1), (-1, -3)]
+)
+@pytest.mark.parametrize("cut_padding", [True, False])
+def test_shift_nth_row_n_steps(
+    shape: tuple[int, ...], axis_row: int, axis_shift: int, cut_padding: bool
+) -> None:
+    array = ivy.ones(shape)
+    shift_nth_row_n_steps(
+        array, axis_row=axis_row, axis_shift=axis_shift, cut_padding=cut_padding
+    )
+
+
+@pytest.mark.parametrize("index", [(0, 0), (0, 1), (1, 0), (1, 1), (3, 4)])
+@pytest.mark.parametrize(
+    "axis_row,axis_shift",
+    [(0, 1), (1, 0), (-2, -1), (-1, -2), (-3, -1), (-1, -3), (-2, -3), (-3, -2)],
+)
+def test_shift_nth_row_n_steps_index(
+    index: tuple[int, int], axis_row: int, axis_shift: int
+) -> None:
+    array = ivy.random.random_uniform(shape=(5, 5, 5))
+    res = shift_nth_row_n_steps(
+        array, axis_row=axis_row, axis_shift=axis_shift, cut_padding=False
+    )
+    assert (
+        res.shape[axis_shift] == array.shape[axis_shift] + array.shape[axis_row] - 1
+    ), f"{array.shape=}, {res.shape=}"
+    assert res.shape[:axis_shift] == array.shape[:axis_shift]
+    if axis_shift != -1:
+        assert res.shape[axis_shift + 1 :] == array.shape[axis_shift + 1 :]
+    assert ivy.allclose(
+        select(
+            select(array, index[0], axis=axis_row).expand_dims(axis=axis_row),
+            index[1],
+            axis=axis_shift,
+        ),
+        select(
+            select(res, index[0], axis=axis_row).expand_dims(axis=axis_row),
+            index[0] + index[1],
+            axis=axis_shift,
+        ),
+    ), f"{array=}, {res=}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,6 @@
+import importlib.util
+from unittest import SkipTest
+
 import ivy
 import pytest
 
@@ -7,7 +10,12 @@ from shift_nth_row_n_steps._main import (
     shift_nth_row_n_steps_for_loop,
 )
 
-ivy.set_backend("numpy")
+
+@pytest.fixture(autouse=True, params=["numpy", "jax", "torch"], scope="session")
+def setup(request: pytest.FixtureRequest) -> None:
+    if importlib.util.find_spec(request.param) is None:
+        raise SkipTest(f"{request.param} is not installed")
+    ivy.set_backend(request.param)
 
 
 def test_shift_nth_row_n_steps_match() -> None:


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/34j/shift-nth-row-n-steps/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/34j/shift-nth-row-n-steps/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
